### PR TITLE
Change appveyor CI. Add docker integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## Build stage
-FROM microsoft/aspnetcore-build:2.0 AS build-env
+FROM microsoft/dotnet:2.1-sdk AS build-env
 WORKDIR /build
 
 # Copy source
@@ -16,7 +16,7 @@ RUN dotnet test test/ServiceHost.Tests/ServiceHost.Tests.csproj /p:SolutionDir=/
 RUN dotnet publish src/ServiceHost/ServiceHost.csproj -o /publish /p:SolutionDir=/build /p:SolutionName=DotNetRu.Server
 
 ## Runtime stage
-FROM microsoft/aspnetcore:2.0
+FROM microsoft/dotnet:2.1-aspnetcore-runtime
 COPY --from=build-env /publish /app
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,18 @@
 FROM microsoft/aspnetcore-build:2.0 AS build-env
 WORKDIR /build
 
-# Restore dependencies
-COPY src/ServiceHost/ServiceHost.csproj ./src/ServiceHost/
-COPY test/ServiceHost.Tests/ServiceHost.Tests.csproj ./test/ServiceHost.Tests/
-
-RUN dotnet restore src/ServiceHost/ServiceHost.csproj
-RUN dotnet restore test/ServiceHost.Tests/ServiceHost.Tests.csproj
-
 # Copy source
 COPY . .
 
+# Restore dependencies
+RUN dotnet restore src/ServiceHost/ServiceHost.csproj /p:SolutionDir=/build /p:SolutionName=DotNetRu.Server
+RUN dotnet restore test/ServiceHost.Tests/ServiceHost.Tests.csproj /p:SolutionDir=/build /p:SolutionName=DotNetRu.Server
+
 # Run tests
-RUN dotnet test test/ServiceHost.Tests/ServiceHost.Tests.csproj
+RUN dotnet test test/ServiceHost.Tests/ServiceHost.Tests.csproj /p:SolutionDir=/build /p:SolutionName=DotNetRu.Server
 
 # Publish stage
-RUN dotnet publish src/ServiceHost/ServiceHost.csproj -o /publish
-
+RUN dotnet publish src/ServiceHost/ServiceHost.csproj -o /publish /p:SolutionDir=/build /p:SolutionName=DotNetRu.Server
 
 ## Runtime stage
 FROM microsoft/aspnetcore:2.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,22 +42,22 @@ for:
     matrix:
       only:
         - image: Visual Studio 2017
-      before_build:
-        - dotnet restore DotNetRu.Server.sln
-      after_test:
-        - dotnet publish ./src/ServiceHost/ServiceHost.csproj --configuration Release --no-restore --output ./../../artifacts /p:SolutionDir=%APPVEYOR_BUILD_FOLDER% /p:SolutionName=DotNetRu.Server
-  -
+    before_build:
+      - dotnet restore DotNetRu.Server.sln
+    after_test:
+      - dotnet publish ./src/ServiceHost/ServiceHost.csproj --configuration Release --no-restore --output ./../../artifacts /p:SolutionDir=%APPVEYOR_BUILD_FOLDER% /p:SolutionName=DotNetRu.Server
+  - 
     matrix:
       only:
         - image: Ubuntu
-      before_build:
-        - dotnet restore DotNetRu.Server.sln
-      build_script:
-        - ps: .\build\build-docker.ps1
-      deploy_script:
-        - ps: .\build\deploy-docker.ps1
-      after_test:
-        - dotnet publish ./src/ServiceHost/ServiceHost.csproj --configuration Release --no-restore --output ./../../artifacts /p:SolutionDir=$APPVEYOR_BUILD_FOLDER /p:SolutionName=DotNetRu.Server
+    before_build:
+      - dotnet restore DotNetRu.Server.sln
+    build_script:
+      - ps: .\build\build-docker.ps1
+    deploy_script:
+      - ps: .\build\deploy-docker.ps1
+    after_test:
+      - dotnet publish ./src/ServiceHost/ServiceHost.csproj --configuration Release --no-restore --output ./../../artifacts /p:SolutionDir=$APPVEYOR_BUILD_FOLDER /p:SolutionName=DotNetRu.Server
 
 build:
   project: DotNetRu.Server.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,10 +23,6 @@ environment:
   DOCKER_PASS:
     secure: 7xusxxMFy9iURl0Ktuzri5XyT3/NDKlsU3kkfJ+Sq90=
 
-branches:
-  only:
-    - master
-
 skip_commits:
   files:
     - README.md
@@ -46,10 +42,19 @@ for:
       - dotnet restore DotNetRu.Server.sln
     after_test:
       - dotnet publish ./src/ServiceHost/ServiceHost.csproj --configuration Release --no-restore --output ./../../artifacts /p:SolutionDir=%APPVEYOR_BUILD_FOLDER% /p:SolutionName=DotNetRu.Server
+  -
+    matrix:
+      only:
+        - image: Ubuntu
+    after_test:
+      - dotnet publish ./src/ServiceHost/ServiceHost.csproj --configuration Release --no-restore --output ./../../artifacts /p:SolutionDir=$APPVEYOR_BUILD_FOLDER /p:SolutionName=DotNetRu.Server
   - 
     matrix:
       only:
         - image: Ubuntu
+    branches:
+      only:
+        - master
     before_build:
       - dotnet restore DotNetRu.Server.sln
     build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 image:
-- Visual Studio 2017
 - Ubuntu
 
 version: 0.1.0.{build}
@@ -20,6 +19,12 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   # Disable sending usage data to Microsoft
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOCKER_PASS:
+    secure: 7xusxxMFy9iURl0Ktuzri5XyT3/NDKlsU3kkfJ+Sq90=
+
+branches:
+  only:
+    - master
 
 skip_commits:
   files:
@@ -28,34 +33,8 @@ skip_commits:
 init:
   - git config --global core.autocrlf false
 
-configuration:
-  - Release
+build_script:
+  - ps: .\build\build-docker.ps1
 
-for:
-  -
-    matrix:
-      only:
-        - image: Visual Studio 2017
-    before_build:
-      - dotnet restore DotNetRu.Server.sln
-    after_test:
-      - dotnet publish ./src/ServiceHost/ServiceHost.csproj --configuration Release --no-restore --output ./../../artifacts /p:SolutionDir=%APPVEYOR_BUILD_FOLDER% /p:SolutionName=DotNetRu.Server
-  -
-    matrix:
-      only:
-        - image: Ubuntu
-    after_test:
-      - dotnet publish ./src/ServiceHost/ServiceHost.csproj --configuration Release --no-restore --output ./../../artifacts /p:SolutionDir=$APPVEYOR_BUILD_FOLDER /p:SolutionName=DotNetRu.Server
-
-build:
-  project: DotNetRu.Server.sln
-  publish_nuget: false
-  publish_aspnet_core: false
-  publish_core_console: false
-  verbosity: minimal
-
-#test_script:
-#  - dotnet build ./test/ServiceHost.Tests/ServiceHost.Tests.csproj --configuration Release /p:SolutionDir=$APPVEYOR_BUILD_FOLDER /p:SolutionName=DotNetRu.Server
-# - dotnet test ./test/ServiceHost.Tests/ServiceHost.Tests.csproj --configuration Release --no-build
-#
-deploy: off
+deploy_script:
+  - ps: .\build\deploy-docker.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 image:
+- Visual Studio 2017
 - Ubuntu
 
 version: 0.1.0.{build}
@@ -33,8 +34,40 @@ skip_commits:
 init:
   - git config --global core.autocrlf false
 
-build_script:
-  - ps: .\build\build-docker.ps1
+configuration:
+  - Release
 
-deploy_script:
-  - ps: .\build\deploy-docker.ps1
+for:
+  -
+    matrix:
+      only:
+        - image: Visual Studio 2017
+      before_build:
+        - dotnet restore DotNetRu.Server.sln
+      after_test:
+        - dotnet publish ./src/ServiceHost/ServiceHost.csproj --configuration Release --no-restore --output ./../../artifacts /p:SolutionDir=%APPVEYOR_BUILD_FOLDER% /p:SolutionName=DotNetRu.Server
+  -
+    matrix:
+      only:
+        - image: Ubuntu
+      before_build:
+        - dotnet restore DotNetRu.Server.sln
+      build_script:
+        - ps: .\build\build-docker.ps1
+      deploy_script:
+        - ps: .\build\deploy-docker.ps1
+      after_test:
+        - dotnet publish ./src/ServiceHost/ServiceHost.csproj --configuration Release --no-restore --output ./../../artifacts /p:SolutionDir=$APPVEYOR_BUILD_FOLDER /p:SolutionName=DotNetRu.Server
+
+build:
+  project: DotNetRu.Server.sln
+  publish_nuget: false
+  publish_aspnet_core: false
+  publish_core_console: false
+  verbosity: minimal
+
+#test_script:
+#  - dotnet build ./test/ServiceHost.Tests/ServiceHost.Tests.csproj --configuration Release /p:SolutionDir=$APPVEYOR_BUILD_FOLDER /p:SolutionName=DotNetRu.Server
+# - dotnet test ./test/ServiceHost.Tests/ServiceHost.Tests.csproj --configuration Release --no-build
+#
+deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,9 @@ for:
     matrix:
       only:
         - image: Ubuntu
+    branches:
+      except:
+        - master
     after_test:
       - dotnet publish ./src/ServiceHost/ServiceHost.csproj --configuration Release --no-restore --output ./../../artifacts /p:SolutionDir=$APPVEYOR_BUILD_FOLDER /p:SolutionName=DotNetRu.Server
   - 

--- a/build/build-docker.ps1
+++ b/build/build-docker.ps1
@@ -1,0 +1,9 @@
+# Prevent windows container build
+if($isWindows){
+    exit 0
+}
+
+Write-Host Starting build docker
+$Version=$env:APPVEYOR_BUILD_VERSION
+
+docker build -t dotnetru/server:latest -t dotnetru/server:$Version .

--- a/build/build-docker.ps1
+++ b/build/build-docker.ps1
@@ -1,8 +1,3 @@
-# Prevent windows container build
-if($isWindows){
-    exit 0
-}
-
 Write-Host Starting build docker
 $Version=$env:APPVEYOR_BUILD_VERSION
 

--- a/build/deploy-docker.ps1
+++ b/build/deploy-docker.ps1
@@ -1,0 +1,16 @@
+# Prevent windows container build
+if($isWindows){
+    exit 0
+}
+
+Write-Host Starting deploy docker
+
+docker images
+
+Write-Host Docker login
+
+$env:DOCKER_PASS | docker login --username dotnetrucd --password-stdin
+
+Write-Host Push to docker hub
+
+docker push dotnetru/server

--- a/build/deploy-docker.ps1
+++ b/build/deploy-docker.ps1
@@ -1,13 +1,7 @@
-# Prevent windows container build
-if($isWindows){
-    exit 0
-}
-
-Write-Host Starting deploy docker
-Write-Host Docker login
+Write-Host Starting deploy docker image
 
 $env:DOCKER_PASS | docker login --username dotnetrucd --password-stdin
 
-Write-Host Push to docker hub
+Write-Host Push image to docker hub
 
 docker push dotnetru/server

--- a/build/deploy-docker.ps1
+++ b/build/deploy-docker.ps1
@@ -4,9 +4,6 @@ if($isWindows){
 }
 
 Write-Host Starting deploy docker
-
-docker images
-
 Write-Host Docker login
 
 $env:DOCKER_PASS | docker login --username dotnetrucd --password-stdin


### PR DESCRIPTION
Изменил CI для appveyor.

Вся линия построения и тестирования осталась в скрипте построения docker образа. Docker образ публикуется в docker hub. Ранее дополнительно обсуждали публикацию Github releases, но решили не делать автоматическую публикацию, так как автоматическое описание \ отсутствие описания не подходит. [PR 36](https://github.com/DotNetRu/Server/pull/36)

Хочу отметить, что оставил построение образа только из master ветки.