### PR TITLE
Добавил регистрацию конфигов для TimePad

### DIFF
--- a/DotNetRuServer.Integration/Common/IntegrationException.cs
+++ b/DotNetRuServer.Integration/Common/IntegrationException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace DotNetRuServer.Integration.Common
+{
+    public class IntegrationException : Exception
+    {
+        public string IntegrationService { get; }
+
+        public IntegrationException(string integrationServiceName, string message) : base(message)
+        {
+            IntegrationService = integrationServiceName;
+        }
+    }
+}

--- a/DotNetRuServer/Startup.cs
+++ b/DotNetRuServer/Startup.cs
@@ -65,7 +65,6 @@ namespace DotNetRuServer
             services.AddScoped<IUnitOfWork, UnitOfWork>();
             services.AddMeetups<SpeakerProvider, TalkProvider, VenueProvider, FriendProvider, MeetupProvider,CommunityProvider, ImageProvider>(_configuration);
             services.AddTimePadIntegration();
-            
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
В конфиги добавил раздел:
```
"Integration": {
    "CommunitiesWithTimePad": []
  }
}
```
в котором будут указываться все сообщества с таймпадом.

Дальше для каждого сообщества токен ищется в конфиге:
```
"Community.Id": {
  "TimePad": {
    "Token": "11111111"
  }
}
```

Соответственно для того, чтобы сервис мог работать с таймпадом сообщества, необходимо добавить в конфиг секцию сообщества с токеном и указать `id` сообщества в списке `CommunitiesWithTimePad`.

Дополнительно добавил `IntegrationException` и проверку на наличе токена при вызове методов сервиса.