### PR TITLE
Smoke-тест для pull request

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -182,3 +182,7 @@ indent_size = 2
 end_of_line = lf
 [*.{cmd, bat}]
 end_of_line = crlf
+
+#YAML workflow files
+[*.{yaml,yml}]
+indent_size = 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET 5.0 SDK
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: "5.0.201"
+        dotnet-version: 5.0.x
 
     - name: restore dependencies
       run: dotnet restore

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,35 @@
+name: Smoke-test
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+
+      - name: restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal --collect:"XPlat code coverage"
+
+      - name: Publish
+        run: dotnet publish DotNetRu.Commune.WasmClient/DotNetRu.Commune.WasmClient.csproj -c Release -o release
+
+      - name: Save
+        uses: actions/upload-artifact@v2
+        with:
+          name: smoke-artifact
+          path: ./release

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [ master ]
 
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,7 +3,7 @@ name: Smoke-test
 on:
   pull_request:
     branches: [ master ]
-    
+
   push:
     branches: [ master ]
 
@@ -26,8 +26,13 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
+      # тестирование и сбор покрытия
       - name: Test
         run: dotnet test --no-restore --verbosity normal --collect:"XPlat code coverage"
+
+      # публикация результатов покрытия тестами на code-cov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
 
       - name: Publish
         run: dotnet publish DotNetRu.Commune.WasmClient/DotNetRu.Commune.WasmClient.csproj -c Release -o release

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,6 +3,10 @@ name: Smoke-test
 on:
   pull_request:
     branches: [ master ]
+    
+  push:
+    branches: [ master ]
+
 
 jobs:
   test:


### PR DESCRIPTION
Сейчас входящие PR не проверяются на валидность, проблемы будут видны только после merge в master.
Добавил workflow для smoke-теста входящих изменений.

Так же 2 небольших изменения:
- отредактировал `.editorconfig` для соответствия поведения локального редактора и редактора github при редактировании YAML
- основной релизный конвеер теперь настроен на последнюю версию .NET 5